### PR TITLE
Remove inline retina safeguard from index.html

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -211,23 +211,5 @@
 
   <!-- JS -->
   <script src="./js/main.js" defer></script>
-
-  <!-- Retina safeguards: if @2x is missing, keep base logo -->
-  <script>
-    (function(){
-      var img = document.getElementById('logoImg');
-      if (!img) return;
-      var probe = new Image();
-      probe.onerror = function(){ img.removeAttribute('srcset'); };
-      probe.src = '/img/logo@2x.png?ts=' + Date.now();
-    })();
-    (function(){
-      var img = document.getElementById('footerLogoImg');
-      if (!img) return;
-      var probe = new Image();
-      probe.onerror = function(){ img.removeAttribute('srcset'); };
-      probe.src = '/img/logo@2x.png?ts=' + Date.now();
-    })();
-  </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- Remove duplicate inline retina-safeguard script in `index.html`
- Keep external `main.js` reference so logos still downgrade if retina asset missing

## Testing
- `npm test` *(fails: Could not read package.json)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b8512c1b0483299405beb478a97394