### PR TITLE
Include about and contact pages in sitemap

### DIFF
--- a/scripts/gen_sitemap.py
+++ b/scripts/gen_sitemap.py
@@ -9,6 +9,8 @@ except Exception:
     pass
 
 urls = [f"{base}/"]
+urls.append(f"{base}/about.html")
+urls.append(f"{base}/contact.html")
 for p in posts:
     u = p.get("permalink") or p.get("external_url")
     if u and u.startswith("http"):


### PR DESCRIPTION
## Summary
- Ensure sitemap generation includes links to about and contact pages.

## Testing
- `python scripts/gen_sitemap.py`
- `cat public/sitemap.xml`

------
https://chatgpt.com/codex/tasks/task_e_68b851be0a888329af3fe3ef084fe31b