### PR TITLE
feat: add dark theme support

### DIFF
--- a/public/css/style.css
+++ b/public/css/style.css
@@ -12,6 +12,20 @@
   --brand-ink:#ffffff;          /* text on brand backgrounds */
   --brand-focus:#00c4cc;        /* focus ring color */
 }
+
+@media (prefers-color-scheme: dark){
+  :root{
+    --bg:#0b0d17;
+    --surface:#1f2937;
+    --text:#f1f5f9;
+    --muted:#9ca3af;
+    --border:#374151;
+    --shadow:0 2px 10px rgba(0,0,0,.5);
+    --brand:#00c4cc;
+    --brand-ink:#000000;
+    --brand-focus:#00c4cc;
+  }
+}
 *{box-sizing:border-box}
 body{
   font-family: Inter, system-ui, -apple-system, Segoe UI, Roboto, Arial, sans-serif;

--- a/public/js/main.js
+++ b/public/js/main.js
@@ -4,6 +4,18 @@ document.addEventListener('DOMContentLoaded', () => {
   if (y) y.textContent = new Date().getFullYear();
 });
 
+/* ========= Theme: track system preference ========= */
+(() => {
+  const mql = window.matchMedia('(prefers-color-scheme: dark)');
+  const root = document.documentElement;
+  const apply = (e) => {
+    root.dataset.theme = e.matches ? 'dark' : 'light';
+    root.style.colorScheme = e.matches ? 'dark' : 'light';
+  };
+  apply(mql);
+  if (mql.addEventListener) mql.addEventListener('change', apply); else mql.addListener(apply);
+})();
+
 /* ========= Slider (automatic, one at a time) ========= */
 (function () {
   const slider = document.querySelector('.slider');


### PR DESCRIPTION
## Summary
- define dark theme CSS variables driven by `prefers-color-scheme`
- track system theme preference in JavaScript for live switches

## Testing
- `npm test` *(fails: Could not read package.json)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b855ae41f483299572bcbb1a39aaff