### PR TITLE
Use theme vars for white surfaces

### DIFF
--- a/public/css/style.css
+++ b/public/css/style.css
@@ -34,12 +34,12 @@ body{
 .container{max-width:980px; margin:2rem auto; padding:0 1rem}
 
 /* Header */
-.site-header{position:sticky; top:0; z-index:50; background:#fff; border-bottom:1px solid var(--border); box-shadow:var(--shadow)}
+.site-header{position:sticky; top:0; z-index:50; background:var(--surface); border-bottom:1px solid var(--border); box-shadow:var(--shadow)}
 .header-inner{display:flex; align-items:center; justify-content:space-between; padding:.6rem 0}
 
 /* Brand link + text */
 .logo{display:inline-flex; align-items:center; gap:.6rem; text-decoration:none; color:var(--text)}
-.logo .brand-text{font-weight:800; font-size:clamp(18px, 2.4vw, 22px); line-height:1; letter-spacing:.2px; color:#111}
+.logo .brand-text{font-weight:800; font-size:clamp(18px, 2.4vw, 22px); line-height:1; letter-spacing:.2px; color:var(--text)}
 
 /* kill any old chip styles on images inside .logo */
 .logo > img{background:none !important; padding:0 !important; border-radius:0 !important}
@@ -68,7 +68,7 @@ body{
 .hero + .section-title{border-bottom:1px solid var(--border); padding-bottom:1rem; margin-bottom:1.5rem}
 
 /* Buttons */
-.btn{display:inline-block; padding:.55rem .9rem; border-radius:10px; border:1px solid #dcdcdc; text-decoration:none; transition:transform .05s, box-shadow .12s; background:#fff; color:#111}
+.btn{display:inline-block; padding:.55rem .9rem; border-radius:10px; border:1px solid var(--border); text-decoration:none; transition:transform .05s, box-shadow .12s; background:var(--surface); color:var(--text)}
 .btn:hover{transform:translateY(-1px); box-shadow:0 4px 12px rgba(0,0,0,.06)}
 .btn-primary{background:var(--brand); color:var(--brand-ink); border-color:var(--brand)}
 
@@ -89,7 +89,7 @@ body{
 
 /* Posts list */
 .hlist{display:grid; gap:1rem}
-.hcard{display:grid; grid-template-columns:180px 1fr; gap:1rem; border:1px solid var(--border); border-radius:var(--radius); background:#fff; padding:1rem; box-shadow:0 2px 6px rgba(0,0,0,.03)}
+.hcard{display:grid; grid-template-columns:180px 1fr; gap:1rem; border:1px solid var(--border); border-radius:var(--radius); background:var(--surface); padding:1rem; box-shadow:0 2px 6px rgba(0,0,0,.03)}
 .hcard-media{display:block}
 .hcard-media img{width:100%; height:100%; object-fit:cover; border-radius:10px; aspect-ratio:16/10}
 .hcard-media.placeholder div{width:100%; height:100%; min-height:120px; border-radius:10px; background:#f1f3f5}
@@ -101,8 +101,8 @@ body{
 
 /* Pager */
 .pager{display:flex; align-items:center; justify-content:center; gap:1rem; margin:1.5rem 0}
-#older{padding:.6rem 1rem; border:1px solid #dcdcdc; border-radius:10px; background:#fff; cursor:pointer; font-weight:600; transition:transform .05s, box-shadow .12s, background .15s}
-#older:hover{transform:translateY(-1px); box-shadow:0 4px 12px rgba(0,0,0,.06); background:#f7f7f7}
+#older{padding:.6rem 1rem; border:1px solid var(--border); border-radius:10px; background:var(--surface); cursor:pointer; font-weight:600; transition:transform .05s, box-shadow .12s, background .15s}
+#older:hover{transform:translateY(-1px); box-shadow:0 4px 12px rgba(0,0,0,.06); background:var(--surface)}
 
 /* Footer */
 footer{border-top:1px solid var(--border); padding-top:2rem}
@@ -112,7 +112,7 @@ footer{border-top:1px solid var(--border); padding-top:2rem}
 
 /* Social icons */
 .socials{display:flex; gap:.75rem; flex-wrap:wrap; margin:.75rem 0 0}
-.icon{display:inline-flex; align-items:center; justify-content:center; width:38px; height:38px; border-radius:10px; border:1px solid var(--border); background:#fff; color:#111; text-decoration:none; transition:transform .06s, box-shadow .12s, background .2s, color .2s; vertical-align:middle}
+.icon{display:inline-flex; align-items:center; justify-content:center; width:38px; height:38px; border-radius:10px; border:1px solid var(--border); background:var(--surface); color:var(--text); text-decoration:none; transition:transform .06s, box-shadow .12s, background .2s, color .2s; vertical-align:middle}
 .icon:hover{transform:translateY(-1px); box-shadow:0 4px 12px rgba(0,0,0,.08)}
 .icon svg{width:18px; height:18px; display:block; flex-shrink:0}
 .icon svg *, .icon svg path, .icon svg circle, .icon svg rect, .icon svg polygon, .icon svg line{fill:currentColor !important; stroke:currentColor !important}
@@ -143,13 +143,13 @@ footer{border-top:1px solid var(--border); padding-top:2rem}
 @media (min-width: 900px) { .grid-2 { grid-template-columns:1.3fr .7fr; } }
 
 /* Cards and stacks */
-.card { background:#fff; border:1px solid #e5e7eb; border-radius:12px; padding:1.25rem; }
+.card { background:var(--surface); border:1px solid var(--border); border-radius:12px; padding:1.25rem; }
 .stack > * + * { margin-top: 1rem; }
 
 /* Form */
 .form-field label { display:block; font-weight:600; margin-bottom:.5rem; }
 .form-field input, .form-field textarea {
-  width:100%; padding:.75rem .85rem; border:1px solid #cbd5e1; border-radius:10px; background:#fff; color:#0f172a;
+  width:100%; padding:.75rem .85rem; border:1px solid var(--border); border-radius:10px; background:var(--surface); color:var(--text);
 }
 .form-field input:focus, .form-field textarea:focus {
   outline: 2px solid var(--brand-focus);


### PR DESCRIPTION
## Summary
- replace hard-coded `#fff` backgrounds with `var(--surface)` so header, buttons, cards, pager, icons, and form fields respond to theme
- ensure text and controls inherit theme colors for better contrast

## Testing
- `rg 'background:#fff' -n public/css/style.css`
- `python -m py_compile scripts/*.py`


------
https://chatgpt.com/codex/tasks/task_e_68b858e17a8c83298ba1d56851475d59