### PR TITLE
Add accessible focus styles for interactive elements

### DIFF
--- a/public/css/style.css
+++ b/public/css/style.css
@@ -63,6 +63,10 @@ body{
 .nav a{text-decoration:none; color:#444; padding:.25rem .2rem; border-radius:8px}
 .nav a.active{font-weight:600; color:var(--brand)}
 .nav a:hover{color:var(--brand)}
+.nav a:focus-visible{
+  outline:2px solid var(--brand-focus);
+  outline-offset:2px;
+}
 
 /* Mobile nav toggle */
 .nav-toggle{
@@ -106,6 +110,7 @@ body{
   .nav[aria-hidden="false"]{display:flex}
   .nav a{color:#111; padding:.55rem .65rem; border-radius:8px; text-decoration:none}
   .nav a:hover{background:#f7f8fa}
+  .nav a:focus-visible{outline:2px solid var(--brand-focus); outline-offset:2px}
 }
 
 @media (min-width: 861px){
@@ -131,6 +136,10 @@ body{
 /* Buttons */
 .btn{display:inline-block; padding:.55rem .9rem; border-radius:10px; border:1px solid var(--border); text-decoration:none; transition:transform .05s, box-shadow .12s; background:var(--surface); color:var(--text)}
 .btn:hover{transform:translateY(-1px); box-shadow:0 4px 12px rgba(0,0,0,.06)}
+.btn:focus-visible{
+  outline:2px solid var(--brand-focus);
+  outline-offset:2px;
+}
 .btn-primary{background:var(--brand); color:var(--brand-ink); border-color:var(--brand)}
 
 /* Slider */
@@ -144,6 +153,10 @@ body{
 .slider-btn{position:absolute; top:50%; transform:translateY(-50%); width:38px; height:38px; border:0; border-radius:50%; background:rgba(255,255,255,.9); box-shadow:0 2px 8px rgba(0,0,0,.12); cursor:pointer; line-height:38px; text-align:center; font-size:22px}
 .slider-btn.prev{left:8px}
 .slider-btn.next{right:8px}
+.slider-btn:focus-visible{
+  outline:2px solid var(--brand-focus);
+  outline-offset:2px;
+}
 .slider-dots{display:flex; gap:6px; justify-content:center; margin-top:.6rem}
 .slider-dots button{width:8px; height:8px; border-radius:50%; border:0; background:#cfcfcf; cursor:pointer}
 .slider-dots button.active{background:var(--brand)}
@@ -189,6 +202,10 @@ footer{border-top:1px solid var(--border); padding-top:2rem}
 .socials{display:flex; gap:.75rem; flex-wrap:wrap; margin:.75rem 0 0}
 .icon{display:inline-flex; align-items:center; justify-content:center; width:38px; height:38px; border-radius:10px; border:1px solid var(--border); background:var(--surface); color:var(--text); text-decoration:none; transition:transform .06s, box-shadow .12s, background .2s, color .2s; vertical-align:middle}
 .icon:hover{transform:translateY(-1px); box-shadow:0 4px 12px rgba(0,0,0,.08)}
+.icon:focus-visible{
+  outline:2px solid var(--brand-focus);
+  outline-offset:2px;
+}
 .icon svg{width:18px; height:18px; display:block; flex-shrink:0}
 .icon svg *, .icon svg path, .icon svg circle, .icon svg rect, .icon svg polygon, .icon svg line{fill:currentColor !important; stroke:currentColor !important}
 .icon.email:hover{background:#d93025; color:#fff; border-color:#d93025}


### PR DESCRIPTION
## Summary
- add consistent `:focus-visible` outlines using `var(--brand-focus)` to buttons, nav links, slider controls, and social icons
- ensure focus indicators meet contrast needs across light and dark themes

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b85d299b848329a83a850539e20ad2