### PR TITLE
Add search filtering to posts list

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -108,6 +108,9 @@
     </section>
 
     <h2 class="section-title">Latest posts</h2>
+    <div class="search-bar">
+      <input id="search" type="search" placeholder="Search posts…" aria-label="Search posts" />
+    </div>
     <div id="posts" class="hlist"></div>
 
     <nav class="pager" id="pager" hidden>


### PR DESCRIPTION
## Summary
- add search input above posts list
- filter posts by query and optional tags and reset pagination

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b85f0c89f88329b9dca220f3c8b175